### PR TITLE
feat: integrate material ui for polished design

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.15.10",
+    "@mui/material": "^5.15.10"
   },
   "devDependencies": {
     "@types/react": "^18.2.14",

--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,0 @@
-form {
-  margin-top: 1rem;
-}
-
-input {
-  margin-right: 0.5rem;
-}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import './App.css'
+import { Container, Typography, TextField, Button, Box } from '@mui/material'
+import SpellcheckIcon from '@mui/icons-material/Spellcheck'
 
 function App() {
   const [word, setWord] = useState('')
@@ -17,18 +18,30 @@ function App() {
   }
 
   return (
-    <>
-      <h1>Spelling Difficulty Calculator</h1>
-      <form onSubmit={handleSubmit}>
-        <input
+    <Container maxWidth="sm" sx={{ mt: 4, textAlign: 'center' }}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        Spelling Difficulty Calculator
+      </Typography>
+      <Box
+        component="form"
+        onSubmit={handleSubmit}
+        sx={{ display: 'flex', gap: 2, justifyContent: 'center', mt: 2 }}
+      >
+        <TextField
+          label="Enter a word"
           value={word}
           onChange={(e) => setWord(e.target.value)}
-          placeholder="Enter a word"
         />
-        <button type="submit">Calculate</button>
-      </form>
-      {score !== null && <p>Difficulty score: {score}</p>}
-    </>
+        <Button variant="contained" type="submit" endIcon={<SpellcheckIcon />}>
+          Calculate
+        </Button>
+      </Box>
+      {score !== null && (
+        <Typography variant="h6" sx={{ mt: 3 }}>
+          Difficulty score: {score}
+        </Typography>
+      )}
+    </Container>
   )
 }
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,15 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
+import { CssBaseline, ThemeProvider, createTheme } from '@mui/material'
+
+const theme = createTheme()
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
   </React.StrictMode>,
 )


### PR DESCRIPTION
## Summary
- replace plain form with Material UI components and icon
- wrap app with Material UI theme provider and baseline for consistent styling
- declare MUI and Emotion dependencies in package.json

## Testing
- `npm run build` *(fails: Cannot resolve '@mui/material' after dependency installation failed with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b00e548230832486cf3ca3acd032e7